### PR TITLE
fix!: change when create database from register endpoint to when run script db:start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
-FROM postgres
-ENV POSTGRES_USER=postgres
-ENV POSTGRES_PASSWORD=local_password
-ENV POSTGRES_DB=local_db
-COPY init.sql /docker-entrypoint-initdb.d/
-
 FROM node
 
 WORKDIR /usr/app
 
 COPY package.json ./
-
+RUN npm install docker
 RUN npm install
 
 COPY . .

--- a/init.sql
+++ b/init.sql
@@ -1,5 +1,9 @@
 CREATE USER local_user;
 
-CREATE DATABASE local_database;
+SELECT 'CREATE DATABASE local_db' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'local_db');
 
-GRANT ALL PRIVILEGES ON DATABASE local_database TO local_user;
+GRANT ALL PRIVILEGES ON DATABASE local_db TO local_user;
+
+CREATE TABLE IF NOT EXISTS public.users (id serial PRIMARY KEY, name varchar(255) NOT NULL, email varchar(255) NOT NULL, password varchar(255), created_at timestamp NOT NULL DEFAULT NOW());
+
+ALTER TABLE public.users OWNER TO local_user;

--- a/src/infra/compose.yaml
+++ b/src/infra/compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - pgdata:/data/postgres
+      - ../../init.sql:/docker-entrypoint-initdb.d/init.sql
   app:
     build: ../../
     container_name: loginApi

--- a/src/modules/accounts/useCases/User/UserUseCase.ts
+++ b/src/modules/accounts/useCases/User/UserUseCase.ts
@@ -81,9 +81,6 @@ class UserUseCase {
   }
 
   static async create({ name, email, password }: IRequest): Promise<IResponse> {
-    await database.query(
-      "CREATE TABLE IF NOT EXISTS public.users (id serial PRIMARY KEY, name varchar(255) NOT NULL, email varchar(255) NOT NULL, password varchar(255), created_at timestamp NOT NULL DEFAULT NOW());",
-    );
 
     const queryResult = await database.query(
       "SELECT * FROM users WHERE email = $1",


### PR DESCRIPTION
BREAKING CHANGE: change docker `compose.yaml` database volume, create database on script `db:start and remove creating database on endpoint register`